### PR TITLE
Fix #205: Remove deprecated maven URL, use mavenCentral().

### DIFF
--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -10,9 +10,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url  "http://tokbox.bintray.com/maven"
-        }
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [X] Code must follow existing styling conventions
- [X] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->
#205